### PR TITLE
collect metadata

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -35,7 +35,7 @@ services:
 
                tag: foobaring.provider
 
-            # Every tagged service will be passed to this method. It’s signature needs to be:
+            # Every tagged service will be passed to this method. Its signature needs to be:
             #
             # `public function addFooBarProvider($index, $foobar)`
             #
@@ -80,6 +80,10 @@ services:
 
               class: FooBaringInterface
 
+            # Define additional metadata on item’s tag. See below for examples
+
+              metadata: null
+
     foobar.provider.cache:
         class: CachedFooBaring
         public: false
@@ -96,4 +100,92 @@ services:
 
             # This will result in calling method `addFooBarProvider` on `foobar.manager`
             # service with parameters: "cache" and `foobar.provider.cache` instance.
+```
+
+## Collecting additional metadata
+
+Sometimes you need some additional configuration on your services. Use `metadata` attribute to
+define a space-separated list of additional attributes allowed on matched items tags. They cannot
+conflict with any other attributes (such as `name`, `priority` or `alias`, etc), and they are not
+validated in any way (use your own `OptionResolver` if needed).
+
+If a single attribute is defined, its value or null will be passed as a third argument to the
+setter method. If multiple, expect an array with any of the used attributes.
+
+### Single value
+
+The `set` method on the `formatter` service will be called once with a scalar value:
+
+```php
+set(0, $locale_item, "en")
+```
+
+```yaml
+services:
+  formatter:
+    class: …
+    tags:
+      - name: nassau.registry
+        tag: formatter.provider
+        metadata: locale
+        method: set
+
+  locale_item:
+    class: …
+    public: false
+    tags:
+      - name: formatter.provider
+        locale: en
+```
+
+### Multiple values
+
+In this case, there will be two calls added to the `movie_quotes` service:
+
+```php
+addQuote("The Hitchhiker’s Guide to the Galaxy", $deep_thought, [
+    'author' => "Deep Thought",
+    'quote' => "the answer to life the universe and everything",
+    'answer' => 42
+]);
+addQuote("unknown", $dont_panic, ['quote' => "Don’t Panic"]);
+```
+
+```yaml
+services:
+  movie_quotes:
+    class: …
+    tags:
+      - name: nassau.registry
+        tag: movie_quotes
+        order: indexed
+        method: addQuote
+
+        # allow any of the three metadata values to be present:
+
+        metadata: "author, quote, answer"
+
+  deep_thought:
+    class: …
+    public: false
+    tags:
+      - name: movie_quotes
+        alias: "The Hitchhiker’s Guide to the Galaxy"
+
+        # below are metadata values:
+
+        author: "Deep Thought"
+        quote: "the answer to life the universe and everything"
+        answer: 42
+
+  dont_panic:
+    class: …
+    public: false
+    tags:
+      - name: movie_quotes
+        alias: "unknown"
+
+        # value & author missing, only ["quote" => …] will be passed
+
+        quote: "Don’t Panic"
 ```

--- a/src/MetaDataIterator.php
+++ b/src/MetaDataIterator.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Nassau\RegistryCompiler;
+
+class MetaDataIterator extends \ArrayObject
+{
+	private $metadata;
+
+	public function __construct()
+	{
+		$this->metadata = new \SplObjectStorage();
+	}
+
+	public function offsetSet($index, $value, $metadata = null)
+	{
+		parent::offsetSet($index, $value);
+		$this->metadata->offsetSet($value, $metadata);
+	}
+
+	public function offsetUnset($index)
+	{
+		if ($this->offsetExists($index)) {
+			$this->metadata->offsetUnset($this->offsetGet($index));
+		}
+		parent::offsetUnset($index);
+	}
+
+	public function getMetaData($object)
+	{
+		return $this->metadata->offsetGet($object);
+	}
+
+}

--- a/src/RegistryCompilerPass.php
+++ b/src/RegistryCompilerPass.php
@@ -12,6 +12,21 @@ class RegistryCompilerPass implements CompilerPassInterface
 	const REGISTRY_TAG_NAME = 'nassau.registry';
 
 	/**
+	 * @var string
+	 */
+	private $tagName;
+
+	/**
+	 * RegistryCompilerPass constructor.
+	 *
+	 * @param string $tagName — you may override the main tag name the library searches for
+	 */
+	public function __construct($tagName = self::REGISTRY_TAG_NAME)
+	{
+		$this->tagName = $tagName;
+	}
+
+	/**
 	 * You can modify the container here before it is dumped to PHP code.
 	 *
 	 * @param ContainerBuilder $container
@@ -20,7 +35,7 @@ class RegistryCompilerPass implements CompilerPassInterface
 	{
 		$optionsResolver = new RegistryTagOptionsResolver();
 
-		foreach ($container->findTaggedServiceIds(self::REGISTRY_TAG_NAME) as $id => $tags) {
+		foreach ($container->findTaggedServiceIds($this->tagName) as $id => $tags) {
 			foreach ($tags as $tag) {
 				try {
 					$tagOptions = $optionsResolver->resolve($tag);
@@ -58,23 +73,35 @@ class RegistryCompilerPass implements CompilerPassInterface
 					}
 				}
 
-				$collection->add($id, $options);
+				$collection->add([$id, $optionsResolver->getMetadata($options)], $options);
 			}
 
 		}
 
 		$targetId = $registryId;
 		$methodName = $tagOptions['method'];
+		$useMetadata = null !== $tagOptions['metadata'];
+
 		if ($tagOptions['use_collection']) {
 			$targetId = "{$registryId}.collection";
-			$container->setDefinition($targetId, new Definition(\ArrayObject::class))->setPublic(false);
+
+			$collectionClass = $useMetadata ? MetaDataIterator::class : \ArrayObject::class;
+			$container->setDefinition($targetId, new Definition($collectionClass))->setPublic(false);
 			$container->getDefinition($registryId)->addMethodCall($methodName, [new Reference($targetId)]);
+
 			$methodName = 'offsetSet';
 		}
 
 		$definition = $container->getDefinition($targetId);
 		foreach ($collection->getIterator() as $key => $item) {
-			$definition->addMethodCall($methodName, [$key, new Reference($item)]);
+			list ($id, $metadata) = $item;
+			$arguments = [$key, new Reference($id)];
+
+			if ($useMetadata) {
+				array_push($arguments, $metadata);
+			}
+
+			$definition->addMethodCall($methodName, $arguments);
 		}
 	}
 

--- a/src/RegistryItemOptionsResolver.php
+++ b/src/RegistryItemOptionsResolver.php
@@ -6,9 +6,13 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class RegistryItemOptionsResolver extends OptionsResolver
 {
+	private $metadata = [];
 
 	public function __construct(array $options)
 	{
+		// tag name:
+		$this->setDefined('name');
+
 		switch ($options['order']) {
 			case RegistryTagOptionsResolver::ORDER_PRIORITY:
 				$this->setDefaults([
@@ -23,5 +27,27 @@ class RegistryItemOptionsResolver extends OptionsResolver
 				break;
 		}
 
+		if (null !== $options['metadata']) {
+			foreach (preg_split('/,?\s+/', $options['metadata']) as $name) {
+				if ($this->isDefined($name)) {
+					throw new \InvalidArgumentException(sprintf(
+						'You cannot use "%s" as metadata since it’s already defined', $name
+					));
+				}
+
+				$this->metadata[] = $name;
+				$this->setDefined($name);
+			}
+		}
+	}
+
+	public function getMetadata($values)
+	{
+		$metadata = array_intersect_key($values, array_flip($this->metadata));
+		if (1 === sizeof($this->metadata)) {
+			list ($metadata) = array_pad(array_values($metadata), 1, null);
+		}
+
+		return $metadata;
 	}
 }

--- a/src/RegistryItemOptionsResolver.php
+++ b/src/RegistryItemOptionsResolver.php
@@ -28,7 +28,7 @@ class RegistryItemOptionsResolver extends OptionsResolver
 		}
 
 		if (null !== $options['metadata']) {
-			foreach (preg_split('/,?\s+/', $options['metadata']) as $name) {
+			foreach (preg_split('/,\s*|,?\s+/', $options['metadata']) as $name) {
 				if ($this->isDefined($name)) {
 					throw new \InvalidArgumentException(sprintf(
 						'You cannot use "%s" as metadata since it’s already defined', $name

--- a/src/RegistryTagOptionsResolver.php
+++ b/src/RegistryTagOptionsResolver.php
@@ -26,11 +26,14 @@ class RegistryTagOptionsResolver extends OptionsResolver
 			'alias_field' => 'alias',
 			// require item to be instance of
 			'class' => null,
+			// additional values passed to setter method
+			'metadata' => null,
 		]);
 
 		$this->setRequired('tag');
 		$this->setAllowedValues('order', [self::ORDER_NATURAL, self::ORDER_PRIORITY, self::ORDER_INDEXED]);
 		$this->setAllowedTypes('use_collection', 'boolean');
+		$this->setAllowedTypes('metadata', ['string', 'null']);
 
 	}
 

--- a/tests/RegistryCompilerPassTest.php
+++ b/tests/RegistryCompilerPassTest.php
@@ -44,4 +44,44 @@ class RegistryCompilerPassTest extends \PHPUnit_Framework_TestCase
 		$this->assertEquals("#FF0000", (string)$names['red']);
 
 	}
+
+	public function testMetadata()
+	{
+		$container = new ContainerBuilder();
+		$container->addCompilerPass(new RegistryCompilerPass());
+		(new YamlFileLoader($container, new FileLocator([__DIR__])))->load('metadata.yml');
+
+		$container->compile();
+
+		$collection = $container->get('metadata_one_value');
+
+		list ($object) = $collection->getArrayCopy();
+		$data = $collection->getMetaData($object);
+
+		$this->assertInstanceOf(\StdClass::class, $object);
+		$this->assertEquals("en", $data);
+
+		// -------------------
+
+		$collection = $container->get('movie_quotes');
+
+		$object = $collection['The Hitchhiker’s Guide to the Galaxy'];
+		$data = $collection->getMetaData($object);
+
+		$this->assertEquals([
+			'author' => 'Deep Thought',
+			'quote' => 'the answer to life the universe and everything',
+			'answer' => 42
+		], $data);
+
+		$object = $collection['unknown'];
+		$data = $collection->getMetaData($object);
+
+		// "author" and "answer" keys are missing:
+		$this->assertArrayNotHasKey('author', $data);
+		$this->assertArrayNotHasKey('answer', $data);
+
+		$this->assertEquals(['quote' => 'Don’t Panic'], $data);
+
+	}
 }

--- a/tests/metadata.yml
+++ b/tests/metadata.yml
@@ -1,0 +1,51 @@
+services:
+  metadata_one_value:
+    class: Nassau\RegistryCompiler\MetaDataIterator
+    tags:
+      - name: nassau.registry
+        tag: metadata_one_value
+        metadata: locale
+        method: offsetSet
+
+  locale_item:
+    class: StdClass
+    public: false
+    tags:
+      - name: metadata_one_value
+        locale: en
+
+  movie_quotes:
+    class: Nassau\RegistryCompiler\MetaDataIterator
+    tags:
+      - name: nassau.registry
+        tag: movie_quotes
+        order: indexed
+        method: offsetSet
+
+        # allow any of the three metadata values to be present:
+
+        metadata: "author, quote, answer"
+
+  deep_thought:
+    class: StdClass
+    public: false
+    tags:
+      - name: movie_quotes
+        alias: "The Hitchhiker’s Guide to the Galaxy"
+
+        # below are metadata values:
+
+        author: "Deep Thought"
+        quote: "the answer to life the universe and everything"
+        answer: 42
+
+  dont_panic:
+    class: StdClass
+    public: false
+    tags:
+      - name: movie_quotes
+        alias: "unknown"
+
+        # value & author: missing
+
+        quote: "Don’t Panic"


### PR DESCRIPTION
@prgtw, what do you think?
# Collecting additional metadata

Sometimes you need some additional configuration on your services. Use `metadata` attribute to
define a space-separated list of additional attributes allowed on matched items tags. They cannot
conflict with any other attributes (such as `name`, `priority` or `alias`, etc), and they are not
validated in any way (use your own `OptionResolver` if needed).

If a single attribute is defined, its value or null will be passed as a third argument to the
setter method. If multiple, expect an array with any of the used attributes.
## Single value

The `set` method on the `formatter` service will be called once with a scalar value:

``` php
set(0, $locale_item, "en")
```

``` yaml
services:
  formatter:
    class: …
    tags:
      - name: nassau.registry
        tag: formatter.provider
        metadata: locale
        method: set

  locale_item:
    class: …
    public: false
    tags:
      - name: formatter.provider
        locale: en
```
## Multiple values

In this case, there will be two calls added to the `movie_quotes` service:

``` php
addQuote("The Hitchhiker’s Guide to the Galaxy", $deep_thought, [
    'author' => "Deep Thought",
    'quote' => "the answer to life the universe and everything",
    'answer' => 42
]);
addQuote("unknown", $dont_panic, ['quote' => "Don’t Panic"]);
```

``` yaml
services:
  movie_quotes:
    class: …
    tags:
      - name: nassau.registry
        tag: movie_quotes
        order: indexed
        method: addQuote

        # allow any of the three metadata values to be present:

        metadata: "author, quote, answer"

  deep_thought:
    class: …
    public: false
    tags:
      - name: movie_quotes
        alias: "The Hitchhiker’s Guide to the Galaxy"

        # below are metadata values:

        author: "Deep Thought"
        quote: "the answer to life the universe and everything"
        answer: 42

  dont_panic:
    class: …
    public: false
    tags:
      - name: movie_quotes
        alias: "unknown"

        # value & author missing, only ["quote" => …] will be passed

        quote: "Don’t Panic"
```
